### PR TITLE
No Json in Env Vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Clean up AWS ECR images based on a git repo
 * Package with Helm
 * Make the script actually fail when things go wrong
     * `os.system` currently just quietly fails
+* Add lint workflow (since this is python now)
+* Add unit tests

--- a/main/src/entrypoint.py
+++ b/main/src/entrypoint.py
@@ -133,7 +133,7 @@ def main():
     """Run the entrypoint script."""
     env = extract_env()
     prepare_git(deploy_key_64=env["GITHUB_DEPLOY_KEY_PRI_64"])
-    container_names = env["CONTAINER_NAMES"].split(",")
+    container_names = [name.strip() for name in env["CONTAINER_NAMES"].split(",")]
     tag_whitelist = get_tag_whitelist(
         github_repository=env["GITHUB_REPOSITORY"],
         container_names=container_names,

--- a/main/src/entrypoint.py
+++ b/main/src/entrypoint.py
@@ -133,7 +133,7 @@ def main():
     """Run the entrypoint script."""
     env = extract_env()
     prepare_git(deploy_key_64=env["GITHUB_DEPLOY_KEY_PRI_64"])
-    container_names = json.loads(env["CONTAINER_NAMES"])
+    container_names = env["CONTAINER_NAMES"].split(",")
     tag_whitelist = get_tag_whitelist(
         github_repository=env["GITHUB_REPOSITORY"],
         container_names=container_names,


### PR DESCRIPTION
It's hard to get json into a kubernetes env var. As such, we're not expecting JSON for the `CONTAINER_NAMES` field anymore. We now use a comma-separated list of strings (spaces after commas are allowed). 